### PR TITLE
DF-1301 Do not cache full responses with error status codes

### DIFF
--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -315,7 +315,8 @@ class Script extends BaseRestService
             $result = ResponseFactory::create($result);
         }
 
-        if ($cacheKey && ($result->getStatusCode() < 300)) {
+        $status = $result->getStatusCode();
+        if ($cacheKey && (($status >= 200) && ($status < 300))) { // do not cache error responses
             $this->addToCache($cacheKey, $result);
         }
 

--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -315,7 +315,7 @@ class Script extends BaseRestService
             $result = ResponseFactory::create($result);
         }
 
-        if ($cacheKey) {
+        if ($cacheKey && ($result->getStatusCode() < 300)) {
             $this->addToCache($cacheKey, $result);
         }
 


### PR DESCRIPTION
Throwing exceptions are caught and not cached naturally, but full event.response formats need to be checked for error status codes.