### PR TITLE
Added python3 support via 'munch', 'http.client', and ()

### DIFF
--- a/src/Engines/Python.php
+++ b/src/Engines/Python.php
@@ -56,8 +56,21 @@ class Python extends ExecutedEngine
         $scriptLines = explode("\n", $script);
 
         $enrobedScript = <<<python
-import httplib, json;
-from bunch import bunchify, unbunchify;
+import json;
+
+try:
+  import http.client as httplib;
+except ImportError:
+  import httplib
+
+try:
+  from munch import munchify as bunchify, unmunchify as unbunchify;
+except ImportError:
+  from bunch import bunchify, unbunchify
+
+import sys
+
+sys.path.append('/home/bitnami/scripts')
 
 eventJson = $jsonEvent;
 platformJson = $jsonPlatform;
@@ -163,7 +176,6 @@ class Api:
                 return path;
 		
 _platform.api = Api(__host, __headers, __protocol);
-
 try:
     def my_closure(event, platform):
 python;
@@ -178,7 +190,7 @@ except Exception as e:
     _event.script_result = {'error':str(e)};
     _event.exception = str(e)
 
-print json.dumps(_event);
+print(json.dumps(_event));
 python;
         $enrobedScript = trim($enrobedScript);
 

--- a/src/Engines/Python.php
+++ b/src/Engines/Python.php
@@ -68,9 +68,6 @@ try:
 except ImportError:
   from bunch import bunchify, unbunchify
 
-import sys
-
-sys.path.append('/home/bitnami/scripts')
 
 eventJson = $jsonEvent;
 platformJson = $jsonPlatform;


### PR DESCRIPTION
Hi, i programmed in support for python3. The update should be 100% transparent.
It consists of:
  1) changing httplib to http.client, if available (maintaining python 2 support)
  2) changing the outdated bunch package to munch, if available
        * munch has support for both python 2 and 3
  3) adding parentheses for the print at the end of the python script, because it's a function in python 3. This is valid in python 2 as well.