### PR TITLE
Add array check for SCM response

### DIFF
--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -124,7 +124,7 @@ class Script extends BaseRestService
                             '_repo/' . $scmRepo,
                             ['path' => $storagePath, 'branch' => $scmRef, 'content' => 1]
                         );
-                        $content = $result->getContent();
+                        $content = is_array($result->getContent()) ? implode($result->getContent()) : $result->getContent();
                     } else {
                         $result = \ServiceManager::handleRequest(
                             $serviceName,


### PR DESCRIPTION
There is a very strange issue. SCM returned an array when getting file content which should be a string at any time. This is hardly reproducible. This change will convert the array response to string.