### PR TITLE
Upgrade df-script to Laravel 13.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "php": "^8.0",
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Handlers/Events/ScriptableEventHandler.php
+++ b/src/Handlers/Events/ScriptableEventHandler.php
@@ -19,13 +19,13 @@ use DreamFactory\Core\Script\Models\EventScript;
 use DreamFactory\Core\System\Resources\Cache;
 use DreamFactory\Core\Utility\ResponseFactory;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Facades\Bus;
 use Log;
 use Illuminate\Support\Arr;
 
 class ScriptableEventHandler
 {
-    use ScriptHandler, DispatchesJobs;
+    use ScriptHandler;
 
     /**
      * Register the listeners for the subscriber.
@@ -143,7 +143,7 @@ class ScriptableEventHandler
             }
         } elseif ($script = $this->getEventScript($event->name . '.queued')) {
             Log::debug('Queued service event script found: ' . $event->name);
-            $result = $this->dispatchNow(new ServiceEventScriptJob($event->name . '.queued', $event, $script->config));
+            $result = Bus::dispatchSync(new ServiceEventScriptJob($event->name . '.queued', $event, $script->config));
             Log::debug('Service event queued: ' . $event->name . PHP_EOL . $result);
         }
 

--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -14,7 +14,7 @@ use DreamFactory\Core\Services\BaseRestService;
 use DreamFactory\Core\Utility\ResourcesWrapper;
 use DreamFactory\Core\Utility\ResponseFactory;
 use DreamFactory\Core\Utility\Session;
-use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Facades\Bus;
 use Log;
 use Illuminate\Support\Arr;
 
@@ -24,7 +24,7 @@ use Illuminate\Support\Arr;
  */
 class Script extends BaseRestService
 {
-    use ScriptHandler, DispatchesJobs;
+    use ScriptHandler;
 
     //*************************************************************************
     //	Members
@@ -275,7 +275,7 @@ class Script extends BaseRestService
         if ($this->queued) {
             $job = new ScriptServiceJob($this->getServiceId(), $this->request, $this->resourcePath,
                 $this->scriptConfig);
-            $result = $this->dispatch($job);
+            $result = Bus::dispatch($job);
             Log::debug('API service script queued: ' . $this->name . PHP_EOL . $result);
 
             return ResponseFactory::create(['success' => true], null, HttpStatusCodeInterface::HTTP_ACCEPTED);


### PR DESCRIPTION
## Summary
- Bump dep matrix to L13.7 (php ^8.3, laravel/framework ^13.7, phpunit ^11.5.3, orchestra/testbench ^11.0); add `laravel/helpers ^1.8` polyfill (matches Wave 0 / df-core).
- Pin sibling df-core to `~1.0.4` and bump df-system floor from `~0.5` to `~0.6.2` to align with the post-L13 sibling chain.
- Replace `Illuminate\Foundation\Bus\DispatchesJobs` trait usage with the `Bus` facade in `Services/Script.php` and `Handlers/Events/ScriptableEventHandler.php`. The trait still exists in L13.7, but no longer exposes `dispatchNow()` — `ScriptableEventHandler` previously called that method and would fatal at runtime under L13. Switching to `Bus::dispatch()` / `Bus::dispatchSync()` decouples this package from a fragile internal trait surface.

## Wave 3 context
- Part of the Laravel 11 -> 13 upgrade campaign. Wave 0 (df-core), Wave 1 (df-system, df-user, df-database, df-sqldb), and Wave 2 connectors already shipped.
- df-script was flagged in Wave 0 memory as the canonical "DispatchesJobs offender." Two import sites confirmed and fixed.

## Test plan
- [x] `composer validate --strict` passes.
- [x] Stage 1 (isolated): `composer install --no-dev` resolves cleanly against shift/laravel-13 path-repos for df-core 1.0.99 and df-system 0.6.99 under PHP 8.3 + L13.7.0.
- [x] Stage 1: `php -l` clean on all 37 src/*.php files.
- [x] Stage 1: `class_exists()` smoke covers every namespaced class in src/ — 37/37 OK.
- [x] Stage 1: helper polyfills `array_get`, `camel_case`, `array_except` resolve via `laravel/helpers`.
- [x] Stage 2: full host-app composer install on `shift-173254` worktree with df-script symlinked in (path-repo); Bus facade resolves; ServiceProvider class loads; Job hierarchy intact (`ScriptJob -> Job` with `InteractsWithQueue` + `SerializesModels`).
- [x] Reflection: confirmed neither patched class still pulls in `Illuminate\Foundation\Bus\DispatchesJobs`.
- [ ] Runtime smoke (queued event-script execution end-to-end) deferred to integration suite once host-app L13 cycle is green.