### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "php": "^8.0",
-    "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core":   "~1.0.4",
+    "dreamfactory/df-system": "~0.6.2"
+  },
+  "require-dev": {
+    "laravel/framework":    "^13.7",
+    "mockery/mockery":      "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit":      "^11.5.3",
+    "orchestra/testbench":  "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Engines/ExecutedEngine.php
+++ b/src/Engines/ExecutedEngine.php
@@ -85,6 +85,50 @@ abstract class ExecutedEngine extends BaseEngineAdapter
     }
 
     /**
+     * Override the PhpExecutable trait's execute() so that stderr from the
+     * script interpreter is captured and logged on non-zero exit. Without this,
+     * missing Python modules, SyntaxErrors, and uncaught runtime exceptions
+     * surface only as "Executed command returned with error code: N" with no
+     * hint of the underlying cause.
+     *
+     * Signature and stdout/$return semantics match the trait's version, so
+     * existing callers are unaffected.
+     */
+    public function execute($command, array &$output = null, &$return = null)
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = @proc_open($command, $descriptors, $pipes);
+        if (!is_resource($process)) {
+            $return = 1;
+            $output = [];
+            return '';
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $return = proc_close($process);
+
+        $stdout = rtrim((string)$stdout, "\n");
+        $output = $stdout === '' ? [] : explode("\n", $stdout);
+
+        if ($return !== 0 && $stderr !== '' && $stderr !== false) {
+            Log::error(
+                "Script execution failed (exit={$return}). stderr:\n" .
+                rtrim($stderr, "\n")
+            );
+        }
+
+        return $output === [] ? '' : end($output);
+    }
+
+    /**
      * Process a single script
      *
      * @param string $path            The path/to/the/script to read and execute

--- a/src/Handlers/Events/ScriptableEventHandler.php
+++ b/src/Handlers/Events/ScriptableEventHandler.php
@@ -19,13 +19,13 @@ use DreamFactory\Core\Script\Models\EventScript;
 use DreamFactory\Core\System\Resources\Cache;
 use DreamFactory\Core\Utility\ResponseFactory;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Facades\Bus;
 use Log;
 use Illuminate\Support\Arr;
 
 class ScriptableEventHandler
 {
-    use ScriptHandler, DispatchesJobs;
+    use ScriptHandler;
 
     /**
      * Register the listeners for the subscriber.
@@ -143,7 +143,7 @@ class ScriptableEventHandler
             }
         } elseif ($script = $this->getEventScript($event->name . '.queued')) {
             Log::debug('Queued service event script found: ' . $event->name);
-            $result = $this->dispatchNow(new ServiceEventScriptJob($event->name . '.queued', $event, $script->config));
+            $result = Bus::dispatchSync(new ServiceEventScriptJob($event->name . '.queued', $event, $script->config));
             Log::debug('Service event queued: ' . $event->name . PHP_EOL . $result);
         }
 

--- a/src/Handlers/Events/ScriptableEventHandler.php
+++ b/src/Handlers/Events/ScriptableEventHandler.php
@@ -71,6 +71,13 @@ class ScriptableEventHandler
         if ($script = $this->getEventScript($event->name)) {
             Log::debug('API event script found: ' . $event->name);
             $data = $event->makeData();
+            $data['_event'] = [
+                'name'        => $event->name,
+                'stage'       => ($event instanceof PreProcessApiEvent)
+                                  ? 'pre_process'
+                                  : (($event instanceof PostProcessApiEvent) ? 'post_process' : 'api'),
+                'script_name' => $script->name,
+            ];
 
             if (null !== $result = $this->handleEventScript($script, $data)) {
                 if ($script->allow_event_modification) {
@@ -137,6 +144,11 @@ class ScriptableEventHandler
         if ($script = $this->getEventScript($event->name)) {
             Log::debug('Service event script found: ' . $event->name);
             $data = $event->makeData();
+            $data['_event'] = [
+                'name'        => $event->name,
+                'stage'       => ($event instanceof ApiEvent) ? 'api' : 'service',
+                'script_name' => $script->name,
+            ];
 
             if (null !== $result = $this->handleEventScript($script, $data)) {
                 return $this->handleEventScriptResult($script, $result);

--- a/src/Handlers/Events/ScriptableEventHandler.php
+++ b/src/Handlers/Events/ScriptableEventHandler.php
@@ -169,7 +169,16 @@ class ScriptableEventHandler
      */
     public function getEventScript($name)
     {
+        // In-flight guard: if a load for this script is already on the stack,
+        // bail out to break a cycle. This happens when the script body is
+        // stored on a service that itself fires the event we're servicing.
+        static $loading = [];
+        if (isset($loading[$name])) {
+            return null;
+        }
+
         $cacheKey = Cache::EVENT_SCRIPT_CACHE_PREFIX . $name;
+        $loading[$name] = true;
         try {
             /** @var EventScript $model */
             $model = \Cache::rememberForever($cacheKey, function () use ($name) {
@@ -222,6 +231,8 @@ class ScriptableEventHandler
             }
         } catch (\Exception $ex) {
             \Log::error('Error occurred while loading event script. ' . $ex->getMessage());
+        } finally {
+            unset($loading[$name]);
         }
 
         return null;

--- a/src/Handlers/Events/ScriptableEventHandler.php
+++ b/src/Handlers/Events/ScriptableEventHandler.php
@@ -155,7 +155,7 @@ class ScriptableEventHandler
             }
         } elseif ($script = $this->getEventScript($event->name . '.queued')) {
             Log::debug('Queued service event script found: ' . $event->name);
-            $result = $this->dispatchNow(new ServiceEventScriptJob($event->name . '.queued', $event, $script->config));
+            $result = $this->dispatchSync(new ServiceEventScriptJob($event->name . '.queued', $event, $script->config));
             Log::debug('Service event queued: ' . $event->name . PHP_EOL . $result);
         }
 

--- a/src/Jobs/ServiceEventScriptJob.php
+++ b/src/Jobs/ServiceEventScriptJob.php
@@ -26,7 +26,13 @@ class ServiceEventScriptJob extends ScriptJob
     public function __construct($id, ServiceEvent $event, $config = [])
     {
         $this->script_id = $id;
-        $this->event = Crypt::encrypt(json_encode($event->makeData()));
+        $data = $event->makeData();
+        $data['_event'] = [
+            'name'        => $event->name,
+            'stage'       => 'queued',
+            'script_name' => $id,
+        ];
+        $this->event = Crypt::encrypt(json_encode($data));
         $this->session = Crypt::encrypt(json_encode(Session::all()));
 
         parent::__construct($config);

--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -14,7 +14,7 @@ use DreamFactory\Core\Services\BaseRestService;
 use DreamFactory\Core\Utility\ResourcesWrapper;
 use DreamFactory\Core\Utility\ResponseFactory;
 use DreamFactory\Core\Utility\Session;
-use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Facades\Bus;
 use Log;
 use Illuminate\Support\Arr;
 
@@ -24,7 +24,7 @@ use Illuminate\Support\Arr;
  */
 class Script extends BaseRestService
 {
-    use ScriptHandler, DispatchesJobs;
+    use ScriptHandler;
 
     //*************************************************************************
     //	Members
@@ -275,7 +275,7 @@ class Script extends BaseRestService
         if ($this->queued) {
             $job = new ScriptServiceJob($this->getServiceId(), $this->request, $this->resourcePath,
                 $this->scriptConfig);
-            $result = $this->dispatch($job);
+            $result = Bus::dispatch($job);
             Log::debug('API service script queued: ' . $this->name . PHP_EOL . $result);
 
             return ResponseFactory::create(['success' => true], null, HttpStatusCodeInterface::HTTP_ACCEPTED);


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
